### PR TITLE
Bump Elixir & Erlang/OTP versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.16-otp-26
+elixir 1.17-otp-26
 erlang 26.2.5.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.17-otp-26
-erlang 26.2.5.1
+elixir 1.17-otp-27
+erlang 27.2


### PR DESCRIPTION
💁 These changes update the versions of Elixir and Erlang/OTP used in development and testing to:
* Elixir: 1.17.3
* Erlang/OTP: 27.2