### PR TITLE
CI: Test with Elixir 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,11 +109,12 @@ jobs:
       fail-fast: false
       matrix:
         otp: ['24', '25', '26', '27']
-        elixir: ['1.15', '1.16', '1.17']
+        elixir: ['1.15', '1.16', '1.17', '1.18']
         exclude:
           - { elixir: '1.15', otp: '27' }
           - { elixir: '1.16', otp: '27' }
           - { elixir: '1.17', otp: '24' }
+          - { elixir: '1.18', otp: '24' }
 
     env:
       MIX_ENV: test

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.17-otp-27
+elixir 1.18-otp-27
 erlang 27.2


### PR DESCRIPTION
💁 These changes introduce Elixir 1.18:
- adds this new version to the test matrix.
- updates the version in `.tool-versions` for local development.