### PR TITLE
Improve ExDoc configuration

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule CompaniesHouse.MixProject do
 
       # Hex
       package: package(),
-      description: "HTTP client for the Companies House API.",
+      description: "Elixir client for the Companies House API",
 
       # Docs
       name: "CompaniesHouse",

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule CompaniesHouse.MixProject do
 
   defp docs do
     [
-      extras: ["README.md", "LICENSE"],
+      extras: ["README.md", "CHANGELOG.md", "LICENSE"],
       main: "readme",
       source_ref: "v#{@version}",
       source_url: @repo_url
@@ -55,7 +55,10 @@ defmodule CompaniesHouse.MixProject do
   defp package do
     [
       licenses: ["MIT"],
-      links: %{"GitHub" => @repo_url}
+      links: %{
+        "GitHub" => @repo_url,
+        "Changelog" => "https://hexdocs.pm/companies_house/changelog.html"
+      }
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -19,12 +19,7 @@ defmodule CompaniesHouse.MixProject do
 
       # Docs
       name: "CompaniesHouse",
-      docs: [
-        extras: ["README.md", "LICENSE"],
-        main: "readme",
-        source_ref: "v#{@version}",
-        source_url: @repo_url
-      ]
+      docs: docs()
     ]
   end
 
@@ -42,6 +37,15 @@ defmodule CompaniesHouse.MixProject do
       {:mox, "~> 1.0", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:expublish, "~> 2.5", only: :dev, runtime: false}
+    ]
+  end
+
+  defp docs do
+    [
+      extras: ["README.md", "LICENSE"],
+      main: "readme",
+      source_ref: "v#{@version}",
+      source_url: @repo_url
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -20,6 +20,8 @@ defmodule CompaniesHouse.MixProject do
       # Docs
       name: "CompaniesHouse",
       docs: [
+        extras: ["README.md", "LICENSE"],
+        main: "readme",
         source_ref: "v#{@version}",
         source_url: @repo_url
       ]

--- a/mix.exs
+++ b/mix.exs
@@ -16,6 +16,8 @@ defmodule CompaniesHouse.MixProject do
       # Hex
       package: package(),
       description: "Elixir client for the Companies House API",
+      homepage_url: @repo_url,
+      source_url: @repo_url,
 
       # Docs
       name: "CompaniesHouse",


### PR DESCRIPTION
💁 The existing [ExDoc](https://github.com/elixir-lang/ex_doc) configuration is used by HexDocs for presentation. Some aspects should be improved, i.e.:
- HexDocs
  - set the homepage to the README
  - include the changelog
- Hex
  - link to the changelog on HexDocs
  - link to the project homepage