### PR TITLE
Actions: Reduce unnecessary jobs in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,8 @@ jobs:
         path: |
           _build
           deps
-        key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-
+        key: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: mix do deps.get, deps.compile


### PR DESCRIPTION
💁 Jobs in Actions workflows have a startup time cost for a runner to pick up the job and execute it, which means that steps should only be broken out into parallelisable jobs when the work being done will take longer than this startup time. The CI Actions workflow has two jobs, dependencies and formatting, which should run much faster as part of the tests job.