### PR TITLE
CI: workflow and job improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Check that mix.lock is up to date
       run: mix deps.get --check-locked
       if: ${{ matrix.lint }}
-    - name: Check code format
+    - name: Check that files are formatted
       run: mix format --check-formatted
       if: ${{ matrix.lint }}
     - name: Check for unused dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
         path: |
           _build
           deps
-        key: ${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-${{ env.MIX_ENV }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-${{ env.MIX_ENV }}-
+        key: ${{ runner.os }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.MIX_ENV }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.MIX_ENV }}-
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  workflow_call:
   push:
     branches: [ "main" ]
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       run: mix deps.unlock --check-unused
       if: ${{ matrix.lint }}
     - name: Compile code
-      run: mix compile
+      run: mix compile --warnings-as-errors
     - name: Run static code analysis
       run: mix credo --strict
       if: ${{ matrix.lint }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,15 @@ permissions:
   contents: read
 
 jobs:
+  required:
+    name: Required
+    needs: [credo, docs, test]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Status of workflow jobs
+        run: echo 'All jobs in this workflow have successfully run'
+
   credo:
     name: Static analysis
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: mix do deps.get, deps.compile
+    - name: Check that mix.lock is up to date
+      run: mix deps.get --check-locked
+      if: ${{ matrix.lint }}
     - name: Check code format
       run: mix format --check-formatted
       if: ${{ matrix.lint }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,44 +13,12 @@ permissions:
 jobs:
   required:
     name: Required
-    needs: [credo, docs, test]
+    needs: [docs, test]
     runs-on: ubuntu-latest
 
     steps:
       - name: Status of workflow jobs
         run: echo 'All jobs in this workflow have successfully run'
-
-  credo:
-    name: Static analysis
-    runs-on: ubuntu-latest
-
-    env:
-      MIX_ENV: test
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Elixir
-      id: setup-beam
-      uses: erlef/setup-beam@v1
-      with:
-        version-file: '.tool-versions'
-        version-type: 'strict'
-    - name: Cache dependencies
-      id: cache-deps
-      uses: actions/cache@v4
-      with:
-        path: |
-          _build
-          deps
-        key: ${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-${{ steps.setup-beam.otp-version }}-${{ steps.setup-beam.elixir-version }}-
-    - name: Install and compile dependencies
-      if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
-    - name: Compile code
-      run: mix compile
-    - name: Run static analysis
-      run: mix credo
 
   docs:
     name: Documentation
@@ -85,7 +53,6 @@ jobs:
   test:
     name: Tests (Elixir ${{ matrix.elixir }} / OTP ${{ matrix.otp }})
     runs-on: ubuntu-latest
-    needs: [credo, docs]
 
     strategy:
       fail-fast: false
@@ -132,5 +99,8 @@ jobs:
       if: ${{ matrix.lint }}
     - name: Compile code
       run: mix compile
+    - name: Run static code analysis
+      run: mix credo --strict
+      if: ${{ matrix.lint }}
     - name: Run tests
       run: mix test --warnings-as-errors

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,12 +14,7 @@ on:
         required: true
 
 jobs:
-  ci:
-    uses: ./.github/workflows/ci.yml
-    secrets: inherit
-
   publish:
-    needs: [ci]
     name: Build and publish to hex.pm
     runs-on: ubuntu-22.04
     env:
@@ -57,4 +52,4 @@ jobs:
       run: echo "${{ inputs.changes }}" > RELEASE.md
 
     - name: Bump version, generate changelog, push to git, publish on hex.pm
-      run: mix expublish.${{ inputs.version }} --branch=main --disable-test
+      run: mix expublish.${{ inputs.version }} --branch=main


### PR DESCRIPTION
💁 These changes improve the GitHub Actions workflows and jobs within continuous integration:
- Define which workflow jobs are required to pass.
- Raise warnings as errors when compiling code.
- Run `Credo` inside the test job instead of a standalone.
- Ensure that `mix.lock` is up-to-date when pulling dependencies.
- Let `Expublish` run the tests inside the publish workflow instead of calling out to the CI workflow.