### PR TITLE
Explicitly set permissions for publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish New Release
+permissions:
+  contents: write
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/sgerrand/ex_companies_house/security/code-scanning/1](https://github.com/sgerrand/ex_companies_house/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves operations like checking out code and pushing changes to Git, we will set `contents: write` as the minimum required permission. If additional permissions are needed for specific actions, they can be added explicitly.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. Alternatively, it can be added to the specific job (`publish`) if the permissions are only relevant to that job.
