### PR TITLE
build: add Lefthook pre-commit hooks and development docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,26 @@ permissions:
 jobs:
   required:
     name: Required
-    needs: [docs, test]
+    needs: [docs, lint-markdown, test]
     runs-on: ubuntu-latest
 
     steps:
       - name: Status of workflow jobs
         run: echo 'All jobs in this workflow have successfully run'
+
+  lint-markdown:
+    name: Markdown lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Lint Markdown files
+      uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265 # v19.1.0
+      with:
+        globs: "**/*.md"
+        config: ".markdownlint-cli2.jsonc"
 
   docs:
     name: Documentation
@@ -47,7 +61,9 @@ jobs:
         restore-keys: ${{ runner.os }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ env.MIX_ENV }}-
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
+      run: |
+        # shellcheck disable=SC1010
+        mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
     - name: Generate documentation
       run: mix docs --warnings-as-errors
 
@@ -93,7 +109,9 @@ jobs:
         restore-keys: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: mix do deps.get, deps.compile
+      run: |
+        # shellcheck disable=SC1010
+        mix do deps.get, deps.compile
     - name: Check that mix.lock is up to date
       run: mix deps.get --check-locked
       if: ${{ matrix.lint }}

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,10 @@
+{
+  // Exclude generated/vendored directories and files managed by tooling
+  "ignores": ["CHANGELOG.md", ".claude/", "_build/", "deps/"],
+  "config": {
+    // Badge URLs and long code examples exceed 80 chars
+    "MD013": false,
+    // CHANGELOG repeats section names (## Added, ## Fixed) across versions
+    "MD024": false
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development
+
+### Setup
+
+```shell
+bin/setup   # installs Homebrew tools and activates Lefthook pre-commit hooks
+mix setup   # fetches Elixir dependencies
+```
+
+`bin/setup` requires [Homebrew](https://brew.sh) and installs: `actionlint`, `check-jsonschema`, `lefthook`, `markdownlint-cli2`.
+
+### Commands
+
+- Run all tests: `mix test`
+- Run single test: `mix test path/to/test_file.exs:line_number`
+- Run specific test file: `mix test path/to/test_file.exs`
+- Lint: `mix credo`
+- Format: `mix format`
+- Test coverage: `mix coveralls`
+
+### Pre-commit hooks (Lefthook)
+
+Activated by `bin/setup`. Hooks run in parallel on staged files:
+
+- `mix-format` — checks `*.{ex,exs}` are formatted
+- `actionlint` — lints GitHub Actions workflow files
+- `check-github-workflows` — validates workflow files against JSON schema
+- `check-dependabot` — validates `.github/dependabot.yml` against JSON schema
+- `check-release-please-config` — validates `release-please-config.json`
+- `check-release-please-manifest` — validates `.release-please-manifest.json`
+- `markdownlint` — lints `*.md` files (config in `.markdownlint-cli2.jsonc`)
+
+## Architecture
+
+This is an Elixir HTTP client library for the [Companies House API](https://developer-specs.company-information.service.gov.uk/) (UK government company data). It is structured in layers:
+
+```text
+CompaniesHouse           ← Public API (11 functions: get_, list_, search_)
+    ↓
+CompaniesHouse.Client    ← Behaviour + struct (environment: :sandbox | :live)
+    ↓
+CompaniesHouse.Client.Req ← Req-based HTTP implementation
+```
+
+**`CompaniesHouse`** is the main facade. All public functions accept optional `params` and `client` keyword args, defaulting to `%Client{}` (sandbox environment).
+
+**`CompaniesHouse.Client`** defines the HTTP behaviour (`get/3`, `post/3`, etc.) and the client struct. The concrete implementation is selected via application config (`config :companies_house, :http_client, ...`), which allows tests to swap in a Mox mock.
+
+**`CompaniesHouse.Client.Req`** builds the Req request with Basic Auth (API key from config), routes to sandbox or live base URL, and normalises responses: 200–299 → `{:ok, body}`, others → `{:error, {status, body}}`.
+
+**`CompaniesHouse.Config`** reads `:api_key` and `:environment` from application config, raising `ConfigError` for missing or invalid values.
+
+## Testing
+
+Tests use **Mox** for unit tests (mock the `Client` behaviour) and **Bypass** for integration tests against `Client.Req` (real HTTP against a local server). The mock is configured in `config/config.exs` for the test environment.
+
+- Tests that mutate application env must use `async: false`.
+- List endpoints extract the `items` key automatically; tests should reflect this.
+- `CompaniesHouse.Response` is excluded from coverage (it's a one-line type alias).
+
+## Conventions
+
+- Environments: `:sandbox` (default, safe) and `:live`.
+- Non-200 HTTP responses surface as `{:error, {status_code, body}}`.
+- List endpoints return `{:ok, [item]}` by extracting `body["items"]`.
+- No Ecto—don't add it. Data is plain maps from JSON responses.
+- All public functions have `@doc`, `@spec`, and doctests where applicable.
+
+At the end of every change, update CLAUDE.md with anything useful that would have been helpful at the start.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,31 @@ def deps do
 end
 ```
 
+## Development
+
+### Requirements
+
+- Elixir (see `.tool-versions` or `mix.exs` for version)
+- [Homebrew](https://brew.sh) (for installing pre-commit hook dependencies)
+
+### Setup
+
+```shell
+bin/setup
+mix setup
+```
+
+`bin/setup` installs the pre-commit hook tools (`actionlint`, `check-jsonschema`, `lefthook`, `markdownlint-cli2`) and activates the hooks. `mix setup` fetches Elixir dependencies.
+
+### Common commands
+
+```shell
+mix test          # Run tests
+mix credo         # Lint
+mix format        # Format code
+mix coveralls     # Test coverage
+```
+
 ## License
 
 CompaniesHouse is [released under the MIT license](LICENSE).

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+brew install actionlint check-jsonschema lefthook markdownlint-cli2
+lefthook install

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,24 @@
+pre-commit:
+  parallel: true
+  commands:
+    mix-format:
+      glob: "*.{ex,exs}"
+      run: mix format --check-formatted
+    actionlint:
+      glob: ".github/workflows/*.yml"
+      run: actionlint {staged_files}
+    check-github-workflows:
+      glob: ".github/workflows/*.yml"
+      run: check-jsonschema --builtin-schema vendor.github-workflows {staged_files}
+    check-dependabot:
+      glob: ".github/dependabot.{yml,yaml}"
+      run: check-jsonschema --builtin-schema vendor.dependabot {staged_files}
+    check-release-please-config:
+      glob: "release-please-config.json"
+      run: check-jsonschema --schemafile https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json {staged_files}
+    check-release-please-manifest:
+      glob: ".release-please-manifest.json"
+      run: check-jsonschema --schemafile https://raw.githubusercontent.com/googleapis/release-please/main/schemas/manifest.json {staged_files}
+    markdownlint:
+      glob: "*.md"
+      run: markdownlint-cli2 {staged_files}


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `bin/setup` to install pre-commit hook tooling via Homebrew (`actionlint`, `check-jsonschema`, `lefthook`, `markdownlint-cli2`) and activate the hooks
- Add `lefthook.yml` with parallel pre-commit hooks: Elixir formatting, GitHub Actions linting, JSON schema validation for workflow/Dependabot/release-please config, and Markdown linting
- Add `.markdownlint-cli2.jsonc` with linting config (ignores generated files; disables MD013 and MD024)
- Add `release-please-config.json` and `.release-please-manifest.json` for automated releases
- Add a Development section to `README.md` and `CLAUDE.md` documenting setup requirements and commands