### PR TITLE
fix: Use string key when extracting items from list responses

### DIFF
--- a/lib/companies_house.ex
+++ b/lib/companies_house.ex
@@ -91,7 +91,7 @@ defmodule CompaniesHouse do
     |> handle_response()
   end
 
-  defp maybe_extract_items({:ok, %{items: items}}), do: {:ok, items}
+  defp maybe_extract_items({:ok, %{"items" => items}}), do: {:ok, items}
 
   defp maybe_extract_items(response_tuple), do: response_tuple
 

--- a/test/companies_house_test.exs
+++ b/test/companies_house_test.exs
@@ -94,7 +94,7 @@ defmodule CompaniesHouseTest do
          %{
            status: 200,
            body: %{
-             items: [
+             "items" => [
                %{
                  category: "some category",
                  date: "some date",
@@ -184,7 +184,7 @@ defmodule CompaniesHouseTest do
         assert path == "/company/12345678/persons-with-significant-control"
         assert client == %Client{environment: :sandbox}
 
-        {:ok, %{status: 200, body: %{items: [%{name: "Jane Bloggs"}, %{name: "John Doe"}]}}}
+        {:ok, %{status: 200, body: %{"items" => [%{name: "Jane Bloggs"}, %{name: "John Doe"}]}}}
       end)
 
       assert {:ok, [%{name: "Jane Bloggs"}, %{name: "John Doe"}]} =
@@ -230,7 +230,7 @@ defmodule CompaniesHouseTest do
         assert path == "/company/12345678/officers"
         assert client == %Client{environment: :sandbox}
 
-        {:ok, %{status: 200, body: %{items: [%{name: "Jane Bloggs"}, %{name: "John Doe"}]}}}
+        {:ok, %{status: 200, body: %{"items" => [%{name: "Jane Bloggs"}, %{name: "John Doe"}]}}}
       end)
 
       assert {:ok, [%{name: "Jane Bloggs"}, %{name: "John Doe"}]} =


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Fix `maybe_extract_items/1` to match on `"items"` (string key) instead of `:items` (atom key)
- Update test fixtures for the three affected list endpoints to use string keys

**Why this matters:** Req decodes JSON with string keys via Jason. The previous atom-key pattern never matched a real API response, so `list_company_officers/3`, `list_filing_history/3`, and `list_persons_with_significant_control/3` were silently returning the full response envelope (`{:ok, %{"items" => [...]}}`) instead of the item list (`{:ok, [...]}`). The tests didn't catch this because mock fixtures used atom keys directly rather than reflecting decoded JSON.