### PR TITLE
fix(test): Serialise tests that mutate application env

### DIFF
--- a/test/companies_house/client/req_test.exs
+++ b/test/companies_house/client/req_test.exs
@@ -1,5 +1,5 @@
 defmodule CompaniesHouse.Client.ReqTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   doctest CompaniesHouse.Client.Req
 

--- a/test/companies_house/client_test.exs
+++ b/test/companies_house/client_test.exs
@@ -1,5 +1,5 @@
 defmodule CompaniesHouse.ClientTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   import Mox, only: [expect: 3, verify_on_exit!: 1]
 


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Set `async: false` in `client_test.exs` and `req_test.exs`

Both files write to `Application.put_env` while using `async: true`. Application env is global mutable state, so concurrent test processes can race on the same keys (`:api_key`, `:environment`) and produce intermittent failures. `config_test.exs` already uses `async: false` for the same reason; this aligns the other two files with that convention.