### PR TITLE
fix: Delegate API key retrieval to Config.api_key/0

### DIFF
--- a/lib/companies_house/client/req.ex
+++ b/lib/companies_house/client/req.ex
@@ -21,7 +21,7 @@ defmodule CompaniesHouse.Client.Req do
   def new(client \\ %Client{}) do
     Req.new(
       base_url: base_url(client.environment),
-      auth: {:basic, api_key()},
+      auth: {:basic, Config.api_key()},
       headers: [{"Accept", "application/json"}]
     )
   end
@@ -77,11 +77,6 @@ defmodule CompaniesHouse.Client.Req do
   def put(path, params \\ [], client \\ %Client{}) do
     new(client)
     |> Req.put(url: path, params: params)
-  end
-
-  defp api_key do
-    Config.get(:api_key) ||
-      Config.raise_error("No :api_key configuration was provided or available.")
   end
 
   defp base_url(environment) do

--- a/test/companies_house/client/req_test.exs
+++ b/test/companies_house/client/req_test.exs
@@ -52,7 +52,7 @@ defmodule CompaniesHouse.Client.ReqTest do
 
       assert_raise(
         CompaniesHouse.Config.ConfigError,
-        "No :api_key configuration was provided or available.",
+        "API key not found in configuration",
         fn ->
           ReqClient.new(%Client{environment: :sandbox})
         end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Remove the private `api_key/0` from `Client.Req` and replace its call site with `Config.api_key()`
- Update the corresponding test to expect the canonical error message from `Config.api_key/0`

`Config.api_key/0` exists to centralise API key retrieval, but `Client.Req` reimplemented the same logic with a different error message (`"No :api_key configuration was provided or available."` vs `"API key not found in configuration"`). This removes the duplication and ensures there is a single source of truth.