### PR TITLE
fix: Raise on unknown environment instead of silently using sandbox

### DIFF
--- a/lib/companies_house/client/req.ex
+++ b/lib/companies_house/client/req.ex
@@ -79,16 +79,9 @@ defmodule CompaniesHouse.Client.Req do
     |> Req.put(url: path, params: params)
   end
 
-  defp base_url(environment) do
-    case environment do
-      :live ->
-        @base_live_url
+  defp base_url(:live), do: @base_live_url
+  defp base_url(:sandbox), do: @base_sandbox_url
 
-      :sandbox ->
-        @base_sandbox_url
-
-      _ ->
-        @base_sandbox_url
-    end
-  end
+  defp base_url(env),
+    do: raise(ArgumentError, "Unknown environment: #{inspect(env)}")
 end

--- a/test/companies_house/client/req_test.exs
+++ b/test/companies_house/client/req_test.exs
@@ -39,12 +39,10 @@ defmodule CompaniesHouse.Client.ReqTest do
       assert client.options.base_url == "https://api-sandbox.company-information.service.gov.uk"
     end
 
-    test "configures sandbox url when given any other environment" do
-      client = ReqClient.new(%Client{environment: :unknown})
-
-      assert Map.has_key?(client, :options)
-      assert Map.has_key?(client.options, :base_url)
-      assert client.options.base_url == "https://api-sandbox.company-information.service.gov.uk"
+    test "raises for unknown environment" do
+      assert_raise ArgumentError, ~r/Unknown environment/, fn ->
+        ReqClient.new(%Client{environment: :unknown})
+      end
     end
 
     test "raises error when api key is not configured" do


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Replace the `_ -> @base_sandbox_url` catch-all in `base_url/1` with an explicit `ArgumentError` raise
- Rewrite the catch-all test to assert the raise rather than the silent fallback

The catch-all was unreachable through the public API — `Client.new/1` validates the environment before any HTTP call is made. The only way to hit it was to construct `%Client{environment: :unknown}` directly. Silently falling back to sandbox for an invalid environment hides misconfiguration; an explicit raise surfaces it immediately.