### PR TITLE
fix: Resolve `http_client` at compile time in `CompaniesHouse` module

### DIFF
--- a/lib/companies_house.ex
+++ b/lib/companies_house.ex
@@ -105,6 +105,6 @@ defmodule CompaniesHouse do
 
   defp handle_response({:error, _} = error), do: error
 
-  defp http_client,
-    do: Application.get_env(:companies_house, :http_client, CompaniesHouse.Client.Req)
+  @http_client Application.compile_env(:companies_house, :http_client, CompaniesHouse.Client.Req)
+  defp http_client, do: @http_client
 end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Replace `Application.get_env/3` with `Application.compile_env/3` (via a module attribute) for the `:http_client` lookup in `CompaniesHouse`

`Client` already binds the HTTP implementation at compile time via `Application.compile_env`. `CompaniesHouse` was using `Application.get_env`, resolving the implementation on every function call at runtime. This inconsistency meant the two modules could theoretically see different implementations if the env changed after compilation. Aligning on `compile_env` makes the binding consistent and lets the compiler warn if the value is altered post-compilation.