### PR TITLE
fix!: remove Config.put/3

### DIFF
--- a/lib/companies_house/config.ex
+++ b/lib/companies_house/config.ex
@@ -22,14 +22,6 @@ defmodule CompaniesHouse.Config do
   end
 
   @doc """
-  Puts a new key value to the configuration.
-  """
-  @spec put(t(), atom(), any()) :: t()
-  def put(config, key, value) do
-    Keyword.put(config, key, value)
-  end
-
-  @doc """
   Raise a ConfigError exception.
   """
   @spec raise_error(binary()) :: no_return

--- a/test/companies_house/config_test.exs
+++ b/test/companies_house/config_test.exs
@@ -43,13 +43,6 @@ defmodule CompaniesHouse.ConfigTest do
     end
   end
 
-  describe "put/3" do
-    test "inserts key value pair" do
-      config = [something: "some value"]
-      assert Config.put(config, :key, 1) == [key: 1, something: "some value"]
-    end
-  end
-
   describe "raise_error/1" do
     test "raises expected exception" do
       assert_raise Config.ConfigError, "some specific error", fn ->


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Remove `Config.put/3` from `CompaniesHouse.Config`
- Remove the corresponding test

`Config.put/3` manipulated a plain keyword list and returned a new one — it did not write to application env and had no effect on the running system. Placed alongside `Config.get/2` (which does read from application env), it implied persistence it could not deliver. The function was never called in production code; any caller can use `Keyword.put/3` directly.

> **Note:** This removes a public function. It is a breaking change for any external code that called `CompaniesHouse.Config.put/3`, warranting a minor version bump.