### PR TITLE
fix(ci): Use `RELEASE_PLEASE_PAT` to allow PR creation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,3 +17,4 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `token: ${{ secrets.RELEASE_PLEASE_PAT }}` to the release-please action

The default `GITHUB_TOKEN` is not permitted to create or approve pull requests in this repository. Using a personal access token (PAT) stored as `RELEASE_PLEASE_PAT` resolves the error:

> GitHub Actions is not permitted to create or approve pull requests.