### PR TITLE
docs: document that search functions return the full response envelope

### DIFF
--- a/lib/companies_house.ex
+++ b/lib/companies_house.ex
@@ -77,6 +77,15 @@ defmodule CompaniesHouse do
   end
 
   # Search
+
+  @doc """
+  Searches for companies matching the given query string.
+
+  Returns the full response envelope, including pagination fields such as
+  `"total_results"` and `"start_index"` alongside `"items"`. This differs
+  from the list functions (e.g. `list_company_officers/3`) which extract
+  only the items array.
+  """
   @spec search_companies(query :: String.t(), params :: keyword(), client :: Client.t()) ::
           Response.t()
   def search_companies(query, params \\ [], client \\ %Client{}) do
@@ -84,6 +93,14 @@ defmodule CompaniesHouse do
     |> handle_response()
   end
 
+  @doc """
+  Searches for officers matching the given query string.
+
+  Returns the full response envelope, including pagination fields such as
+  `"total_results"` and `"start_index"` alongside `"items"`. This differs
+  from the list functions (e.g. `list_company_officers/3`) which extract
+  only the items array.
+  """
   @spec search_officers(query :: String.t(), params :: keyword(), client :: Client.t()) ::
           Response.t()
   def search_officers(query, params \\ [], client \\ %Client{}) do


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `@doc` to `search_companies/3` and `search_officers/3` explaining that they return the full response envelope

The search endpoints return pagination metadata (`total_results`, `start_index`) alongside `items`, so they intentionally do not call `maybe_extract_items/1`. Without documentation this looks like an oversight compared to the list functions. The new `@doc` makes the distinction explicit for callers.