### PR TITLE
feat: add stream_* functions for auto-paginating list endpoints

### DIFF
--- a/lib/companies_house.ex
+++ b/lib/companies_house.ex
@@ -20,6 +20,23 @@ defmodule CompaniesHouse do
       # Use the live environment
       client = CompaniesHouse.Client.new(:live)
       {:ok, officers} = CompaniesHouse.list_company_officers("00000006", [], client)
+
+  ## Streaming / auto-pagination
+
+  The `stream_*` functions automatically paginate through all results, fetching
+  100 items per page and yielding each item individually. They return a lazy
+  `Stream` (an `Enumerable`), so you can pipe them into `Enum` functions:
+
+      # Collect all officers for a company
+      all_officers = CompaniesHouse.stream_company_officers("00000006") |> Enum.to_list()
+
+      # Stream lazily — only fetch pages as needed
+      CompaniesHouse.stream_filing_history("00000006")
+      |> Stream.filter(&(&1["type"] == "AA"))
+      |> Enum.take(5)
+
+  If the API returns an error for any page, that page is silently skipped and
+  the stream stops.
   """
 
   alias CompaniesHouse.Client
@@ -95,6 +112,54 @@ defmodule CompaniesHouse do
     |> handle_response()
   end
 
+  # Streaming / auto-pagination
+
+  @doc """
+  Streams all officers for a company, automatically paginating through results.
+
+  Fetches up to 100 items per page and yields each officer individually. The
+  stream is lazy: pages are only fetched as items are consumed.
+
+  Returns an `Enumerable` (a lazy `Stream`).
+  """
+  @spec stream_company_officers(String.t(), keyword(), Client.t()) :: Enumerable.t()
+  def stream_company_officers(company_number, params \\ [], client \\ %Client{}) do
+    stream_paginated("/company/#{company_number}/officers", params, client)
+  end
+
+  @doc """
+  Streams all filing history entries for a company, automatically paginating
+  through results.
+
+  Fetches up to 100 items per page and yields each filing history entry
+  individually. The stream is lazy: pages are only fetched as items are consumed.
+
+  Returns an `Enumerable` (a lazy `Stream`).
+  """
+  @spec stream_filing_history(String.t(), keyword(), Client.t()) :: Enumerable.t()
+  def stream_filing_history(company_number, params \\ [], client \\ %Client{}) do
+    stream_paginated("/company/#{company_number}/filing-history", params, client)
+  end
+
+  @doc """
+  Streams all persons with significant control for a company, automatically
+  paginating through results.
+
+  Fetches up to 100 items per page and yields each person individually. The
+  stream is lazy: pages are only fetched as items are consumed.
+
+  Returns an `Enumerable` (a lazy `Stream`).
+  """
+  @spec stream_persons_with_significant_control(String.t(), keyword(), Client.t()) ::
+          Enumerable.t()
+  def stream_persons_with_significant_control(company_number, params \\ [], client \\ %Client{}) do
+    stream_paginated(
+      "/company/#{company_number}/persons-with-significant-control",
+      params,
+      client
+    )
+  end
+
   # Search
 
   @doc """
@@ -125,6 +190,29 @@ defmodule CompaniesHouse do
   def search_officers(query, params \\ [], client \\ %Client{}) do
     http_client().get("/search/officers", [q: query] ++ params, client)
     |> handle_response()
+  end
+
+  defp stream_paginated(path, params, client) do
+    Stream.unfold({0, false}, fn
+      {_start, true} ->
+        nil
+
+      {start_index, false} ->
+        merged_params = Keyword.merge(params, start_index: start_index, items_per_page: 100)
+
+        case http_client().get(path, merged_params, client) |> handle_response() do
+          {:ok, %{"items" => items, "total_results" => total}} ->
+            done = start_index + length(items) >= total
+            {items, {start_index + length(items), done}}
+
+          {:ok, %{"items" => items}} ->
+            {items, {start_index + length(items), true}}
+
+          _ ->
+            nil
+        end
+    end)
+    |> Stream.flat_map(& &1)
   end
 
   defp maybe_extract_items({:ok, %{"items" => items}}), do: {:ok, items}

--- a/test/companies_house_test.exs
+++ b/test/companies_house_test.exs
@@ -274,6 +274,188 @@ defmodule CompaniesHouseTest do
     end
   end
 
+  describe "stream_company_officers/3" do
+    test "streams all officers across multiple pages" do
+      expect(MockHTTPClient, :get, fn path, params, client ->
+        assert path == "/company/12345678/officers"
+        assert params[:start_index] == 0
+        assert params[:items_per_page] == 100
+        assert client == %Client{environment: :sandbox}
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "items" => [%{"name" => "Officer A"}, %{"name" => "Officer B"}],
+             "total_results" => 3
+           }
+         }}
+      end)
+
+      expect(MockHTTPClient, :get, fn path, params, _client ->
+        assert path == "/company/12345678/officers"
+        assert params[:start_index] == 2
+        assert params[:items_per_page] == 100
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "items" => [%{"name" => "Officer C"}],
+             "total_results" => 3
+           }
+         }}
+      end)
+
+      result = CompaniesHouse.stream_company_officers("12345678") |> Enum.to_list()
+
+      assert result == [
+               %{"name" => "Officer A"},
+               %{"name" => "Officer B"},
+               %{"name" => "Officer C"}
+             ]
+    end
+
+    test "streams all officers when total_results is absent" do
+      expect(MockHTTPClient, :get, fn _path, params, _client ->
+        assert params[:start_index] == 0
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{"items" => [%{"name" => "Officer A"}]}
+         }}
+      end)
+
+      result = CompaniesHouse.stream_company_officers("12345678") |> Enum.to_list()
+      assert result == [%{"name" => "Officer A"}]
+    end
+
+    test "stops stream on API error" do
+      expect(MockHTTPClient, :get, fn _path, _params, _client ->
+        {:ok, %{status: 404, body: %{"error" => "Company not found"}}}
+      end)
+
+      result = CompaniesHouse.stream_company_officers("12345678") |> Enum.to_list()
+      assert result == []
+    end
+
+    test "merges caller-supplied params" do
+      expect(MockHTTPClient, :get, fn path, params, _client ->
+        assert path == "/company/12345678/officers"
+        assert params[:register_view] == "directors"
+        assert params[:items_per_page] == 100
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "items" => [%{"name" => "Director A"}],
+             "total_results" => 1
+           }
+         }}
+      end)
+
+      result =
+        CompaniesHouse.stream_company_officers("12345678", register_view: "directors")
+        |> Enum.to_list()
+
+      assert result == [%{"name" => "Director A"}]
+    end
+  end
+
+  describe "stream_filing_history/3" do
+    test "streams all filing history entries across multiple pages" do
+      expect(MockHTTPClient, :get, fn path, params, _client ->
+        assert path == "/company/12345678/filing-history"
+        assert params[:start_index] == 0
+        assert params[:items_per_page] == 100
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "items" => [%{"type" => "AA"}, %{"type" => "CS01"}],
+             "total_results" => 3
+           }
+         }}
+      end)
+
+      expect(MockHTTPClient, :get, fn _path, params, _client ->
+        assert params[:start_index] == 2
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "items" => [%{"type" => "TM01"}],
+             "total_results" => 3
+           }
+         }}
+      end)
+
+      result = CompaniesHouse.stream_filing_history("12345678") |> Enum.to_list()
+      assert result == [%{"type" => "AA"}, %{"type" => "CS01"}, %{"type" => "TM01"}]
+    end
+
+    test "stops stream on API error" do
+      expect(MockHTTPClient, :get, fn _path, _params, _client ->
+        {:ok, %{status: 404, body: %{"error" => "Company not found"}}}
+      end)
+
+      result = CompaniesHouse.stream_filing_history("12345678") |> Enum.to_list()
+      assert result == []
+    end
+  end
+
+  describe "stream_persons_with_significant_control/3" do
+    test "streams all PSCs across multiple pages" do
+      expect(MockHTTPClient, :get, fn path, params, _client ->
+        assert path == "/company/12345678/persons-with-significant-control"
+        assert params[:start_index] == 0
+        assert params[:items_per_page] == 100
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "items" => [%{"name" => "Jane Bloggs"}],
+             "total_results" => 2
+           }
+         }}
+      end)
+
+      expect(MockHTTPClient, :get, fn _path, params, _client ->
+        assert params[:start_index] == 1
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "items" => [%{"name" => "John Doe"}],
+             "total_results" => 2
+           }
+         }}
+      end)
+
+      result =
+        CompaniesHouse.stream_persons_with_significant_control("12345678") |> Enum.to_list()
+
+      assert result == [%{"name" => "Jane Bloggs"}, %{"name" => "John Doe"}]
+    end
+
+    test "stops stream on API error" do
+      expect(MockHTTPClient, :get, fn _path, _params, _client ->
+        {:ok, %{status: 404, body: %{"error" => "Company not found"}}}
+      end)
+
+      result =
+        CompaniesHouse.stream_persons_with_significant_control("12345678") |> Enum.to_list()
+
+      assert result == []
+    end
+  end
+
   describe "search_companies/3" do
     test "returns search results when successful" do
       expect(MockHTTPClient, :get, fn path, params, client ->


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `stream_company_officers/3`, `stream_filing_history/3`, and `stream_persons_with_significant_control/3` functions that automatically paginate through all results using `Stream.unfold/2`
- Each stream function fetches 100 items per page and yields items individually as a lazy `Enumerable`, so pages are only fetched as items are consumed
- A shared `stream_paginated/3` private helper avoids repeating the pagination logic
- Pagination stops when `start_index + items_returned >= total_results`, or when the response contains no `total_results` field (treating it as the final page), or on any API error
- Add 9 tests covering multi-page streaming, single-page streaming, caller-provided params, and error handling for all three functions
- Update `@moduledoc` with a "Streaming / auto-pagination" section and usage examples