### PR TITLE
feat: emit telemetry events around HTTP requests

### DIFF
--- a/lib/companies_house/client/req.ex
+++ b/lib/companies_house/client/req.ex
@@ -32,8 +32,9 @@ defmodule CompaniesHouse.Client.Req do
   """
   @spec delete(path :: nonempty_binary, client :: Client.t()) :: Response.t()
   def delete(path, client \\ %Client{}) do
-    new(client)
-    |> Req.delete(url: path)
+    with_telemetry(:delete, path, client, fn ->
+      new(client) |> Req.delete(url: path)
+    end)
   end
 
   @impl true
@@ -42,8 +43,9 @@ defmodule CompaniesHouse.Client.Req do
   """
   @spec get(path :: nonempty_binary, client :: Client.t()) :: Response.t()
   def get(path, client) do
-    new(client)
-    |> Req.get(url: path)
+    with_telemetry(:get, path, client, fn ->
+      new(client) |> Req.get(url: path)
+    end)
   end
 
   @impl true
@@ -53,8 +55,9 @@ defmodule CompaniesHouse.Client.Req do
   @spec get(path :: nonempty_binary, params :: keyword(), client :: Client.t()) ::
           Response.t()
   def get(path, params, client) do
-    new(client)
-    |> Req.get(url: path, params: params)
+    with_telemetry(:get, path, client, fn ->
+      new(client) |> Req.get(url: path, params: params)
+    end)
   end
 
   @impl true
@@ -64,8 +67,9 @@ defmodule CompaniesHouse.Client.Req do
   @spec post(path :: nonempty_binary, params :: keyword(), client :: Client.t()) ::
           Response.t()
   def post(path, params \\ [], client \\ %Client{}) do
-    new(client)
-    |> Req.post(url: path, params: params)
+    with_telemetry(:post, path, client, fn ->
+      new(client) |> Req.post(url: path, params: params)
+    end)
   end
 
   @impl true
@@ -75,8 +79,9 @@ defmodule CompaniesHouse.Client.Req do
   @spec put(path :: nonempty_binary, params :: keyword(), client :: Client.t()) ::
           Response.t()
   def put(path, params \\ [], client \\ %Client{}) do
-    new(client)
-    |> Req.put(url: path, params: params)
+    with_telemetry(:put, path, client, fn ->
+      new(client) |> Req.put(url: path, params: params)
+    end)
   end
 
   defp base_url(:live), do: @base_live_url
@@ -84,4 +89,35 @@ defmodule CompaniesHouse.Client.Req do
 
   defp base_url(env),
     do: raise(ArgumentError, "Unknown environment: #{inspect(env)}")
+
+  defp with_telemetry(method, path, client, fun) do
+    metadata = %{method: method, path: path, environment: client.environment}
+    start = System.monotonic_time()
+
+    :telemetry.execute(
+      [:companies_house, :request, :start],
+      %{system_time: System.system_time()},
+      metadata
+    )
+
+    result = fun.()
+
+    case result do
+      {:ok, response} ->
+        :telemetry.execute(
+          [:companies_house, :request, :stop],
+          %{duration: System.monotonic_time() - start},
+          Map.put(metadata, :status, response.status)
+        )
+
+      {:error, reason} ->
+        :telemetry.execute(
+          [:companies_house, :request, :exception],
+          %{duration: System.monotonic_time() - start},
+          Map.merge(metadata, %{kind: :error, reason: reason})
+        )
+    end
+
+    result
+  end
 end

--- a/lib/companies_house/telemetry.ex
+++ b/lib/companies_house/telemetry.ex
@@ -1,0 +1,52 @@
+defmodule CompaniesHouse.Telemetry do
+  @moduledoc """
+  Telemetry events emitted by the Companies House client.
+
+  ## Events
+
+  ### `[:companies_house, :request, :start]`
+
+  Emitted before each HTTP request.
+
+  **Measurements:** `%{system_time: integer()}`
+
+  **Metadata:** `%{method: atom(), path: String.t(), environment: :live | :sandbox}`
+
+  ### `[:companies_house, :request, :stop]`
+
+  Emitted after a completed HTTP request (including non-2xx responses).
+
+  **Measurements:** `%{duration: integer()}`
+
+  **Metadata:** `%{method: atom(), path: String.t(), environment: :live | :sandbox, status: pos_integer()}`
+
+  ### `[:companies_house, :request, :exception]`
+
+  Emitted when the HTTP request encounters a transport error (e.g. connection
+  refused, timeout, DNS failure).
+
+  **Measurements:** `%{duration: integer()}`
+
+  **Metadata:** `%{method: atom(), path: String.t(), environment: :live | :sandbox, kind: :error, reason: term()}`
+
+  ## Attaching handlers
+
+  Use `:telemetry.attach/4` or `:telemetry.attach_many/4`:
+
+      :telemetry.attach_many(
+        "my-app-companies-house",
+        [
+          [:companies_house, :request, :start],
+          [:companies_house, :request, :stop],
+          [:companies_house, :request, :exception]
+        ],
+        fn event, measurements, metadata, _config ->
+          IO.inspect({event, measurements, metadata})
+        end,
+        nil
+      )
+
+  Durations are in native time units. Convert to milliseconds with
+  `System.convert_time_unit(duration, :native, :millisecond)`.
+  """
+end

--- a/mix.exs
+++ b/mix.exs
@@ -42,6 +42,7 @@ defmodule CompaniesHouse.MixProject do
   defp deps do
     [
       {:req, "~> 0.5.6"},
+      {:telemetry, "~> 1.0"},
       {:bypass, "~> 2.1", only: :test},
       {:excoveralls, "~> 0.18", only: :test},
       {:mox, "~> 1.0", only: :test},

--- a/test/companies_house/telemetry_test.exs
+++ b/test/companies_house/telemetry_test.exs
@@ -1,0 +1,134 @@
+defmodule CompaniesHouse.TelemetryTest do
+  use ExUnit.Case, async: false
+
+  alias CompaniesHouse.Client
+  alias CompaniesHouse.Client.Req, as: ReqClient
+
+  @handler_id "companies-house-telemetry-test"
+
+  setup do
+    Application.put_env(:companies_house, :api_key, "test-key")
+
+    on_exit(fn ->
+      Application.delete_env(:companies_house, :api_key)
+      :telemetry.detach(@handler_id)
+    end)
+
+    :ok
+  end
+
+  describe "[:companies_house, :request, :start]" do
+    setup [:setup_bypass]
+
+    @tag path: "/company/12345678"
+    test "emits start event before the request", c do
+      test_pid = self()
+
+      :telemetry.attach(
+        @handler_id,
+        [:companies_house, :request, :start],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:telemetry_start, measurements, metadata})
+        end,
+        nil
+      )
+
+      Bypass.expect_once(c.bypass, "GET", c.path, fn conn ->
+        Plug.Conn.resp(conn, 200, ~s({}))
+      end)
+
+      ReqClient.get(c.url, c.client)
+
+      assert_receive {:telemetry_start, measurements, metadata}
+      assert is_integer(measurements.system_time)
+      assert metadata.method == :get
+      assert metadata.environment == :sandbox
+    end
+  end
+
+  describe "[:companies_house, :request, :stop]" do
+    setup [:setup_bypass]
+
+    @tag path: "/company/12345678"
+    test "emits stop event with status after successful request", c do
+      test_pid = self()
+
+      :telemetry.attach(
+        @handler_id,
+        [:companies_house, :request, :stop],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:telemetry_stop, measurements, metadata})
+        end,
+        nil
+      )
+
+      Bypass.expect_once(c.bypass, "GET", c.path, fn conn ->
+        Plug.Conn.resp(conn, 200, ~s({"company_name": "Test Ltd"}))
+      end)
+
+      ReqClient.get(c.url, c.client)
+
+      assert_receive {:telemetry_stop, measurements, metadata}
+      assert is_integer(measurements.duration)
+      assert measurements.duration >= 0
+      assert metadata.method == :get
+      assert metadata.status == 200
+      assert metadata.environment == :sandbox
+    end
+
+    @tag path: "/company/missing"
+    test "emits stop event with status for non-2xx responses", c do
+      test_pid = self()
+
+      :telemetry.attach(
+        @handler_id,
+        [:companies_house, :request, :stop],
+        fn _event, _measurements, metadata, _config ->
+          send(test_pid, {:telemetry_stop, metadata})
+        end,
+        nil
+      )
+
+      Bypass.expect_once(c.bypass, "GET", c.path, fn conn ->
+        Plug.Conn.resp(conn, 404, ~s({"error": "not found"}))
+      end)
+
+      ReqClient.get(c.url, c.client)
+
+      assert_receive {:telemetry_stop, metadata}
+      assert metadata.status == 404
+    end
+  end
+
+  describe "[:companies_house, :request, :exception]" do
+    test "emits exception event on transport error" do
+      test_pid = self()
+
+      :telemetry.attach(
+        @handler_id,
+        [:companies_house, :request, :exception],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:telemetry_exception, measurements, metadata})
+        end,
+        nil
+      )
+
+      # Port 1 refuses connections immediately
+      client = %Client{environment: :sandbox}
+      ReqClient.get("http://localhost:1/company/12345678", client)
+
+      assert_receive {:telemetry_exception, measurements, metadata}, 15_000
+      assert is_integer(measurements.duration)
+      assert metadata.method == :get
+      assert metadata.kind == :error
+      assert metadata.environment == :sandbox
+    end
+  end
+
+  defp setup_bypass(%{path: path}) do
+    bypass = Bypass.open()
+    client = %Client{environment: :sandbox}
+    url = "http://localhost:#{bypass.port}#{path}"
+    [bypass: bypass, client: client, url: url]
+  end
+end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `:telemetry ~> 1.0` as an explicit runtime dependency (it was already a transitive dep via Req/Finch)
- Add a private `with_telemetry/4` helper in `CompaniesHouse.Client.Req` that wraps every HTTP method (`get/2`, `get/3`, `post/3`, `put/3`, `delete/2`) with three standard telemetry events:
  - `[:companies_house, :request, :start]` — emitted before the request with `system_time` measurement and `method`/`path`/`environment` metadata
  - `[:companies_house, :request, :stop]` — emitted after any completed request (including non-2xx) with `duration` measurement and `status` added to metadata
  - `[:companies_house, :request, :exception]` — emitted on transport errors with `duration` measurement and `kind`/`reason` added to metadata
- Add `CompaniesHouse.Telemetry` module documenting all events, their measurements, metadata, and an example of attaching a handler
- Add `test/companies_house/telemetry_test.exs` with 4 tests covering start events, stop events on success, stop events on non-2xx responses, and exception events on transport failures