### PR TITLE
feat: add charges, insolvency, exemptions, UK establishments, and officer search endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Activated by `bin/setup`. Hooks run in parallel on staged files:
 This is an Elixir HTTP client library for the [Companies House API](https://developer-specs.company-information.service.gov.uk/) (UK government company data). It is structured in layers:
 
 ```text
-CompaniesHouse           ← Public API (11 functions: get_, list_, search_)
+CompaniesHouse           ← Public API (18 functions: get_, list_, search_)
     ↓
 CompaniesHouse.Client    ← Behaviour + struct (environment: :sandbox | :live)
     ↓

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Activated by `bin/setup`. Hooks run in parallel on staged files:
 This is an Elixir HTTP client library for the [Companies House API](https://developer-specs.company-information.service.gov.uk/) (UK government company data). It is structured in layers:
 
 ```text
-CompaniesHouse           ← Public API (18 functions: get_, list_, search_)
+CompaniesHouse           ← Public API (20 functions: get_, list_, search_, stream_)
     ↓
 CompaniesHouse.Client    ← Behaviour + struct (environment: :sandbox | :live)
     ↓
@@ -67,6 +67,8 @@ Tests use **Mox** for unit tests (mock the `Client` behaviour) and **Bypass** fo
 - Environments: `:sandbox` (default, safe) and `:live`.
 - Non-200 HTTP responses surface as `{:error, {status_code, body}}`; network/transport failures surface as `{:error, exception}`. Both shapes are captured by `Response.error()`.
 - List endpoints return `{:ok, [item]}` by extracting `body["items"]`.
+- Search endpoints return `{:ok, map()}` with the full response envelope (pagination fields included alongside `"items"`).
+- `stream_*` functions return `Enumerable.t()` (a lazy `Stream`), not `Response.t()`. They auto-paginate at 100 items per page and stop silently on API error.
 - No Ecto—don't add it. Data is plain maps from JSON responses.
 - All public functions have `@doc`, `@spec`, and doctests where applicable.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ config :companies_house, environment: :live
 
 ### Return values
 
-- `get_*` and `list_*` return `{:ok, map()} | {:ok, [map()]} | {:error, {status, body}}`.
+- `get_*` and `list_*` return `{:ok, map()}` or `{:ok, [map()]}` on success. Errors are either `{:error, {status_code, body}}` for non-2xx HTTP responses or `{:error, exception}` for network/transport failures (e.g. timeout, connection refused).
 - `search_*` return the full response envelope (including `"total_results"` and `"start_index"`), not just the items array.
 - `stream_*` return a lazy `Enumerable` that auto-paginates. Pipe into `Enum` or `Stream` functions.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,76 @@ def deps do
 end
 ```
 
+## Usage
+
+### Configuration
+
+Add your API key to your application config:
+
+```elixir
+config :companies_house, api_key: "your-api-key"
+```
+
+By default the client targets the sandbox environment. To use the live API:
+
+```elixir
+config :companies_house, environment: :live
+```
+
+### Available functions
+
+#### Company data
+
+- `get_company_profile/2`
+- `get_registered_office_address/2`
+- `get_insolvency/2`
+- `get_exemptions/2`
+
+#### Officers
+
+- `list_company_officers/3`
+- `get_officer_appointment/3`
+- `list_officer_appointments/3`
+
+#### Filing history
+
+- `list_filing_history/3`
+- `get_filing_history/3`
+
+#### Persons with significant control
+
+- `list_persons_with_significant_control/3`
+- `get_person_with_significant_control/3`
+
+#### Charges
+
+- `list_charges/3`
+- `get_charge/3`
+
+#### UK establishments
+
+- `list_uk_establishments/3`
+
+#### Search
+
+- `search_companies/3`
+- `search_officers/3`
+- `search_disqualified_officers/3`
+
+#### Streaming (auto-pagination)
+
+- `stream_company_officers/3`
+- `stream_filing_history/3`
+- `stream_persons_with_significant_control/3`
+
+### Return values
+
+- `get_*` and `list_*` return `{:ok, map()} | {:ok, [map()]} | {:error, {status, body}}`.
+- `search_*` return the full response envelope (including `"total_results"` and `"start_index"`), not just the items array.
+- `stream_*` return a lazy `Enumerable` that auto-paginates. Pipe into `Enum` or `Stream` functions.
+
+See the [HexDocs](https://hexdocs.pm/companies_house/) for full API reference.
+
 ## Development
 
 ### Requirements

--- a/lib/companies_house.ex
+++ b/lib/companies_house.ex
@@ -21,6 +21,25 @@ defmodule CompaniesHouse do
       client = CompaniesHouse.Client.new(:live)
       {:ok, officers} = CompaniesHouse.list_company_officers("00000006", [], client)
 
+  ## Available functions
+
+  Company data: `get_company_profile/2`, `get_registered_office_address/2`,
+  `get_insolvency/2`, `get_exemptions/2`
+
+  Officers: `list_company_officers/3`, `get_officer_appointment/3`,
+  `list_officer_appointments/3`
+
+  Filing history: `list_filing_history/3`, `get_filing_history/3`
+
+  Persons with significant control: `list_persons_with_significant_control/3`,
+  `get_person_with_significant_control/3`
+
+  Charges: `list_charges/3`, `get_charge/3`
+
+  UK establishments: `list_uk_establishments/3`
+
+  Search: `search_companies/3`, `search_officers/3`, `search_disqualified_officers/3`
+
   ## Streaming / auto-pagination
 
   The `stream_*` functions automatically paginate through all results, fetching
@@ -160,6 +179,79 @@ defmodule CompaniesHouse do
     )
   end
 
+  # Charges
+
+  @doc """
+  Lists charges for the given company number.
+
+  Returns the items array extracted from the response body.
+  """
+  @spec list_charges(String.t(), keyword(), Client.t()) :: Response.t()
+  def list_charges(company_number, params \\ [], client \\ %Client{}) do
+    http_client().get("/company/#{company_number}/charges", params, client)
+    |> handle_response()
+    |> maybe_extract_items()
+  end
+
+  @doc """
+  Returns a single charge for the given company number and charge ID.
+  """
+  @spec get_charge(String.t(), String.t(), Client.t()) :: Response.t()
+  def get_charge(company_number, charge_id, client \\ %Client{}) do
+    http_client().get("/company/#{company_number}/charges/#{charge_id}", client)
+    |> handle_response()
+  end
+
+  # Insolvency
+
+  @doc """
+  Returns insolvency details for the given company number.
+  """
+  @spec get_insolvency(String.t(), Client.t()) :: Response.t()
+  def get_insolvency(company_number, client \\ %Client{}) do
+    http_client().get("/company/#{company_number}/insolvency", client)
+    |> handle_response()
+  end
+
+  # Exemptions
+
+  @doc """
+  Returns exemptions for the given company number.
+  """
+  @spec get_exemptions(String.t(), Client.t()) :: Response.t()
+  def get_exemptions(company_number, client \\ %Client{}) do
+    http_client().get("/company/#{company_number}/exemptions", client)
+    |> handle_response()
+  end
+
+  # UK Establishments
+
+  @doc """
+  Lists UK establishments for the given company number.
+
+  Returns the items array extracted from the response body.
+  """
+  @spec list_uk_establishments(String.t(), keyword(), Client.t()) :: Response.t()
+  def list_uk_establishments(company_number, params \\ [], client \\ %Client{}) do
+    http_client().get("/company/#{company_number}/uk-establishments", params, client)
+    |> handle_response()
+    |> maybe_extract_items()
+  end
+
+  # Officer Appointments (by officer ID)
+
+  @doc """
+  Lists appointments for the given officer ID.
+
+  Returns the items array extracted from the response body.
+  """
+  @spec list_officer_appointments(String.t(), keyword(), Client.t()) :: Response.t()
+  def list_officer_appointments(officer_id, params \\ [], client \\ %Client{}) do
+    http_client().get("/officers/#{officer_id}/appointments", params, client)
+    |> handle_response()
+    |> maybe_extract_items()
+  end
+
   # Search
 
   @doc """
@@ -189,6 +281,20 @@ defmodule CompaniesHouse do
           Response.t()
   def search_officers(query, params \\ [], client \\ %Client{}) do
     http_client().get("/search/officers", [q: query] ++ params, client)
+    |> handle_response()
+  end
+
+  @doc """
+  Searches for disqualified officers matching the given query string.
+
+  Returns the full response envelope, including pagination fields such as
+  `"total_results"` and `"start_index"` alongside `"items"`. This differs
+  from the list functions (e.g. `list_company_officers/3`) which extract
+  only the items array.
+  """
+  @spec search_disqualified_officers(String.t(), keyword(), Client.t()) :: Response.t()
+  def search_disqualified_officers(query, params \\ [], client \\ %Client{}) do
+    http_client().get("/search/disqualified-officers", [q: query] ++ params, client)
     |> handle_response()
   end
 

--- a/test/companies_house_test.exs
+++ b/test/companies_house_test.exs
@@ -536,4 +536,197 @@ defmodule CompaniesHouseTest do
                CompaniesHouse.search_officers("some unknown officer")
     end
   end
+
+  describe "list_charges/3" do
+    test "returns list of charges when successful" do
+      expect(MockHTTPClient, :get, fn path, _params, client ->
+        assert path == "/company/12345678/charges"
+        assert client == %Client{environment: :sandbox}
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{"items" => [%{"charge_number" => 1}, %{"charge_number" => 2}]}
+         }}
+      end)
+
+      assert {:ok, [%{"charge_number" => 1}, %{"charge_number" => 2}]} =
+               CompaniesHouse.list_charges("12345678")
+    end
+
+    test "returns error when request fails" do
+      expect(MockHTTPClient, :get, fn _path, _params, _client ->
+        {:ok, %{status: 404, body: %{"error" => "Company not found"}}}
+      end)
+
+      assert {:error, {404, %{"error" => "Company not found"}}} =
+               CompaniesHouse.list_charges("12345678")
+    end
+  end
+
+  describe "get_charge/3" do
+    test "returns charge when successful" do
+      expect(MockHTTPClient, :get, fn path, client ->
+        assert path == "/company/12345678/charges/abc123"
+        assert client == %Client{environment: :sandbox}
+
+        {:ok, %{status: 200, body: %{"charge_number" => 1, "status" => "outstanding"}}}
+      end)
+
+      assert {:ok, %{"charge_number" => 1, "status" => "outstanding"}} =
+               CompaniesHouse.get_charge("12345678", "abc123")
+    end
+
+    test "returns error when request fails" do
+      expect(MockHTTPClient, :get, fn _path, _client ->
+        {:ok, %{status: 404, body: %{"error" => "Charge not found"}}}
+      end)
+
+      assert {:error, {404, %{"error" => "Charge not found"}}} =
+               CompaniesHouse.get_charge("12345678", "abc123")
+    end
+  end
+
+  describe "get_insolvency/2" do
+    test "returns insolvency details when successful" do
+      expect(MockHTTPClient, :get, fn path, client ->
+        assert path == "/company/12345678/insolvency"
+        assert client == %Client{environment: :sandbox}
+
+        {:ok, %{status: 200, body: %{"cases" => [%{"type" => "administration"}]}}}
+      end)
+
+      assert {:ok, %{"cases" => [%{"type" => "administration"}]}} =
+               CompaniesHouse.get_insolvency("12345678")
+    end
+
+    test "returns error when request fails" do
+      expect(MockHTTPClient, :get, fn _path, _client ->
+        {:ok, %{status: 404, body: %{"error" => "Company not found"}}}
+      end)
+
+      assert {:error, {404, %{"error" => "Company not found"}}} =
+               CompaniesHouse.get_insolvency("12345678")
+    end
+  end
+
+  describe "get_exemptions/2" do
+    test "returns exemptions when successful" do
+      expect(MockHTTPClient, :get, fn path, client ->
+        assert path == "/company/12345678/exemptions"
+        assert client == %Client{environment: :sandbox}
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{"exemptions" => %{"psc_exempt_as_trading_on_uk_regulated_market" => %{}}}
+         }}
+      end)
+
+      assert {:ok, %{"exemptions" => %{"psc_exempt_as_trading_on_uk_regulated_market" => %{}}}} =
+               CompaniesHouse.get_exemptions("12345678")
+    end
+
+    test "returns error when request fails" do
+      expect(MockHTTPClient, :get, fn _path, _client ->
+        {:ok, %{status: 404, body: %{"error" => "Company not found"}}}
+      end)
+
+      assert {:error, {404, %{"error" => "Company not found"}}} =
+               CompaniesHouse.get_exemptions("12345678")
+    end
+  end
+
+  describe "list_uk_establishments/3" do
+    test "returns list of UK establishments when successful" do
+      expect(MockHTTPClient, :get, fn path, _params, client ->
+        assert path == "/company/12345678/uk-establishments"
+        assert client == %Client{environment: :sandbox}
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "items" => [%{"company_number" => "BR000001"}, %{"company_number" => "BR000002"}]
+           }
+         }}
+      end)
+
+      assert {:ok, [%{"company_number" => "BR000001"}, %{"company_number" => "BR000002"}]} =
+               CompaniesHouse.list_uk_establishments("12345678")
+    end
+
+    test "returns error when request fails" do
+      expect(MockHTTPClient, :get, fn _path, _params, _client ->
+        {:ok, %{status: 404, body: %{"error" => "Company not found"}}}
+      end)
+
+      assert {:error, {404, %{"error" => "Company not found"}}} =
+               CompaniesHouse.list_uk_establishments("12345678")
+    end
+  end
+
+  describe "list_officer_appointments/3" do
+    test "returns list of officer appointments when successful" do
+      expect(MockHTTPClient, :get, fn path, _params, client ->
+        assert path == "/officers/officer123/appointments"
+        assert client == %Client{environment: :sandbox}
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{"items" => [%{"appointed_to" => %{"company_number" => "12345678"}}]}
+         }}
+      end)
+
+      assert {:ok, [%{"appointed_to" => %{"company_number" => "12345678"}}]} =
+               CompaniesHouse.list_officer_appointments("officer123")
+    end
+
+    test "returns error when request fails" do
+      expect(MockHTTPClient, :get, fn _path, _params, _client ->
+        {:ok, %{status: 404, body: %{"error" => "Officer not found"}}}
+      end)
+
+      assert {:error, {404, %{"error" => "Officer not found"}}} =
+               CompaniesHouse.list_officer_appointments("officer123")
+    end
+  end
+
+  describe "search_disqualified_officers/3" do
+    test "returns search results when successful" do
+      expect(MockHTTPClient, :get, fn path, params, client ->
+        assert path == "/search/disqualified-officers"
+        assert params == [q: "John Doe", items_per_page: 10]
+        assert client == %Client{environment: :sandbox}
+
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "items" => [%{"name" => "John Doe"}],
+             "total_results" => 1,
+             "start_index" => 0
+           }
+         }}
+      end)
+
+      assert {:ok,
+              %{
+                "items" => [%{"name" => "John Doe"}],
+                "total_results" => 1,
+                "start_index" => 0
+              }} =
+               CompaniesHouse.search_disqualified_officers("John Doe", items_per_page: 10)
+    end
+
+    test "returns error when request fails" do
+      expect(MockHTTPClient, :get, fn _path, _params, _client ->
+        {:ok, %{status: 404, body: %{"error" => "Officer not found"}}}
+      end)
+
+      assert {:error, {404, %{"error" => "Officer not found"}}} =
+               CompaniesHouse.search_disqualified_officers("Unknown Person")
+    end
+  end
 end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `list_charges/3` and `get_charge/3` for the `/company/{number}/charges` endpoints
- Add `get_insolvency/2` for the `/company/{number}/insolvency` endpoint
- Add `get_exemptions/2` for the `/company/{number}/exemptions` endpoint
- Add `list_uk_establishments/3` for the `/company/{number}/uk-establishments` endpoint
- Add `list_officer_appointments/3` for the `/officers/{id}/appointments` endpoint (appointments for a given officer across all companies)
- Add `search_disqualified_officers/3` for the `/search/disqualified-officers` endpoint, returning the full response envelope consistent with other search functions
- Add 12 new tests (success + error cases for each new endpoint), following existing patterns
- All new functions have `@doc`, `@spec`, and follow existing conventions (list functions extract `"items"`, get/search functions return the full body)
- Add a "Usage" section to `README.md` covering configuration, all available functions grouped by domain, and a return value guide noting the `list_*` / `search_*` / `stream_*` differences
- Update `CLAUDE.md` to reflect the new function count (20) and `stream_` prefix, and add convention bullets for `search_*` and `stream_*` return types