### PR TITLE
fix: narrow Response.t error type from any() to concrete union

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,12 +60,12 @@ Tests use **Mox** for unit tests (mock the `Client` behaviour) and **Bypass** fo
 
 - Tests that mutate application env must use `async: false`.
 - List endpoints extract the `items` key automatically; tests should reflect this.
-- `CompaniesHouse.Response` is excluded from coverage (it's a one-line type alias).
+- `CompaniesHouse.Response` is excluded from coverage (it's a type-only module).
 
 ## Conventions
 
 - Environments: `:sandbox` (default, safe) and `:live`.
-- Non-200 HTTP responses surface as `{:error, {status_code, body}}`.
+- Non-200 HTTP responses surface as `{:error, {status_code, body}}`; network/transport failures surface as `{:error, exception}`. Both shapes are captured by `Response.error()`.
 - List endpoints return `{:ok, [item]}` by extracting `body["items"]`.
 - No Ecto—don't add it. Data is plain maps from JSON responses.
 - All public functions have `@doc`, `@spec`, and doctests where applicable.

--- a/lib/companies_house/response.ex
+++ b/lib/companies_house/response.ex
@@ -1,7 +1,14 @@
 defmodule CompaniesHouse.Response do
   @moduledoc """
-  The response tuple.
+  The response type returned by all public API functions.
+
+  Successful responses return `{:ok, map()}` with the parsed JSON body.
+
+  Errors take one of two shapes:
+  - `{:error, {status_code, body}}` — the API returned a non-2xx HTTP response
+  - `{:error, exception}` — a network or transport failure (e.g. timeout, DNS failure)
   """
 
-  @type t :: {:ok, map() | [map()]} | {:error, any()}
+  @type error :: {pos_integer(), map()} | Exception.t()
+  @type t :: {:ok, map() | [map()]} | {:error, error()}
 end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Narrow `Response.t` error type from `{:error, any()}` to `{:error, error()}` where `error()` is the new `Response.error` type alias
- `Response.error` is defined as `{pos_integer(), map()} | Exception.t()`, capturing the two concrete error shapes: HTTP error responses (a `{status_code, body}` tuple) and transport/network failures (an `Exception.t()`)
- Update `@moduledoc` on `CompaniesHouse.Response` to explain both error shapes with prose
- Update `CLAUDE.md` to document both error shapes in the Conventions section
- No runtime behaviour changes — this is a type-only narrowing that makes dialyzer more precise and clarifies the contract for library consumers