### PR TITLE
fix: widen Response.t() success type to include list return from list_* functions

### DIFF
--- a/lib/companies_house/response.ex
+++ b/lib/companies_house/response.ex
@@ -3,5 +3,5 @@ defmodule CompaniesHouse.Response do
   The response tuple.
   """
 
-  @type t :: {:ok, map()} | {:error, any()}
+  @type t :: {:ok, map() | [map()]} | {:error, any()}
 end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- `Response.t()` declared `{:ok, map()}` as the success type, but `list_*` functions pipe through `maybe_extract_items/1` which extracts `body["items"]` and returns `{:ok, [map()]}` — a list, not a map
- Widen the success branch to `{:ok, map() | [map()]}` to accurately reflect both return shapes: single-resource functions (`get_*`, `search_*`) return a map; list functions (`list_*`) return a list of maps
- No runtime behaviour change — type-only correction