### PR TITLE
ci: split code coverage into separate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,49 @@ jobs:
         globs: "**/*.md"
         config: ".markdownlint-cli2.jsonc"
 
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      checks: write
+
+    env:
+      MIX_ENV: test
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Set up Elixir
+      id: setup-beam
+      uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+      with:
+        elixir-version: '1.18'
+        otp-version: '27'
+    - name: Cache dependencies
+      id: cache-deps
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: |
+          _build
+          deps
+        key: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-
+    - name: Install and compile dependencies
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: |
+        # shellcheck disable=SC1010
+        mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
+    - name: Generate coverage report
+      run: mix coveralls.lcov
+    - name: Upload coverage to Coveralls
+      uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
+      with:
+        file: cover/lcov.info
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest
@@ -128,8 +171,3 @@ jobs:
       if: ${{ matrix.lint }}
     - name: Run tests
       run: mix test --warnings-as-errors
-    - name: Report code coverage to Coveralls
-      run: mix coveralls.github
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      if: ${{ matrix.lint }}


### PR DESCRIPTION
💁 These changes separate the steps which generate and post code coverage to [Coveralls](https://coveralls.io) into a separate job in the existing GitHub Actions workflow. This ensures that the test jobs will not fail if Coveralls is unavailable when code coverage is posted there.