### PR TITLE
fix(test): silence mix test warnings

### DIFF
--- a/lib/companies_house/client/req.ex
+++ b/lib/companies_house/client/req.ex
@@ -22,7 +22,8 @@ defmodule CompaniesHouse.Client.Req do
     Req.new(
       base_url: base_url(client.environment),
       auth: {:basic, Config.api_key()},
-      headers: [{"Accept", "application/json"}]
+      headers: [{"Accept", "application/json"}],
+      retry: false
     )
   end
 

--- a/test/companies_house/telemetry_test.exs
+++ b/test/companies_house/telemetry_test.exs
@@ -22,15 +22,11 @@ defmodule CompaniesHouse.TelemetryTest do
 
     @tag path: "/company/12345678"
     test "emits start event before the request", c do
-      test_pid = self()
-
       :telemetry.attach(
         @handler_id,
         [:companies_house, :request, :start],
-        fn _event, measurements, metadata, _config ->
-          send(test_pid, {:telemetry_start, measurements, metadata})
-        end,
-        nil
+        &__MODULE__.handle_start/4,
+        self()
       )
 
       Bypass.expect_once(c.bypass, "GET", c.path, fn conn ->
@@ -51,15 +47,11 @@ defmodule CompaniesHouse.TelemetryTest do
 
     @tag path: "/company/12345678"
     test "emits stop event with status after successful request", c do
-      test_pid = self()
-
       :telemetry.attach(
         @handler_id,
         [:companies_house, :request, :stop],
-        fn _event, measurements, metadata, _config ->
-          send(test_pid, {:telemetry_stop, measurements, metadata})
-        end,
-        nil
+        &__MODULE__.handle_stop/4,
+        self()
       )
 
       Bypass.expect_once(c.bypass, "GET", c.path, fn conn ->
@@ -78,15 +70,11 @@ defmodule CompaniesHouse.TelemetryTest do
 
     @tag path: "/company/missing"
     test "emits stop event with status for non-2xx responses", c do
-      test_pid = self()
-
       :telemetry.attach(
         @handler_id,
         [:companies_house, :request, :stop],
-        fn _event, _measurements, metadata, _config ->
-          send(test_pid, {:telemetry_stop, metadata})
-        end,
-        nil
+        &__MODULE__.handle_stop_metadata_only/4,
+        self()
       )
 
       Bypass.expect_once(c.bypass, "GET", c.path, fn conn ->
@@ -102,15 +90,11 @@ defmodule CompaniesHouse.TelemetryTest do
 
   describe "[:companies_house, :request, :exception]" do
     test "emits exception event on transport error" do
-      test_pid = self()
-
       :telemetry.attach(
         @handler_id,
         [:companies_house, :request, :exception],
-        fn _event, measurements, metadata, _config ->
-          send(test_pid, {:telemetry_exception, measurements, metadata})
-        end,
-        nil
+        &__MODULE__.handle_exception/4,
+        self()
       )
 
       # Port 1 refuses connections immediately
@@ -123,6 +107,22 @@ defmodule CompaniesHouse.TelemetryTest do
       assert metadata.kind == :error
       assert metadata.environment == :sandbox
     end
+  end
+
+  def handle_start(_event, measurements, metadata, test_pid) do
+    send(test_pid, {:telemetry_start, measurements, metadata})
+  end
+
+  def handle_stop(_event, measurements, metadata, test_pid) do
+    send(test_pid, {:telemetry_stop, measurements, metadata})
+  end
+
+  def handle_stop_metadata_only(_event, _measurements, metadata, test_pid) do
+    send(test_pid, {:telemetry_stop, metadata})
+  end
+
+  def handle_exception(_event, measurements, metadata, test_pid) do
+    send(test_pid, {:telemetry_exception, measurements, metadata})
   end
 
   defp setup_bypass(%{path: path}) do


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Disable Req's built-in retry behaviour in `Client.Req.new/1` by setting `retry: false`. As a library, retry strategy belongs to the consumer — the default caused spurious `[warning] retry: got response with status 500` and `retry: got exception` log lines during tests.
- Replace anonymous function handlers in `TelemetryTest` with named public module functions captured as `&__MODULE__.function/4`, passing the test PID via the handler config argument. This silences the `:telemetry` runtime warning about local functions incurring a performance penalty.

## Test plan

- [x] `mix test` runs with 89 passing tests and no warnings